### PR TITLE
chore: export redlock types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittl/node-redlock",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "description": "A node.js redlock implementation for distributed redis locks",
   "license": "MIT",
   "author": {
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "keywords": [


### PR DESCRIPTION
<!-- ignore-task-list-start -->
**Description:**

Export redlock types

**This PR includes:**

- Add index.d.ts to package exports

**How to run:**

N/A

**Demo:**

N/A

<!-- ignore-task-list-end -->
**Checklist (based on [PR guidelines](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2)):**

- [X] I have self-reviewed this PR, according to [these points](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#cce74429793a46aa9e448cbe8ed97221)
- [X] This PR falls into maximum three of [these categories](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#bc286233220540079736bb5460c562dc)
- [X] I feel comfortable taking responsibility for merging this code to production
- [X] The code is high quality, [well-tested](https://www.notion.so/kittl/Unit-testing-guide-4ff179324baa42f08af2a88d1408e901), follows styles guides ([Frontend](https://www.notion.so/kittl/Kittl-Frontend-Code-Style-65978cb3d3134936960bff045b92972f)), clean, and well documented
